### PR TITLE
Add default configuration and environment template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Environment variable defaults for the Podcast Theme Analyzer project.
+# Copy this file to `.env` and update the values with your local secrets.
+
+APP_ENV=development
+LOG_LEVEL=INFO
+DATABASE_PATH=data/transcripts.db
+RAW_AUDIO_DIR=data/raw_audio
+CACHE_DIR=cache
+
+# Message queue configuration
+REDIS_URL=redis://localhost:6379/0
+
+# External service credentials
+OPENAI_API_KEY=your-openai-api-key
+TRANSCRIPTION_API_KEY=your-transcription-service-key

--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -1,0 +1,32 @@
+{
+  "runtime": {
+    "environment": "development"
+  },
+  "paths": {
+    "data_dir": "data",
+    "database": "data/transcripts.db",
+    "raw_audio_dir": "data/raw_audio",
+    "cache_dir": "cache"
+  },
+  "ingestion": {
+    "poll_interval_seconds": 300,
+    "max_concurrent_jobs": 4
+  },
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "temperature": 0.2,
+    "max_tokens": 2048
+  },
+  "logging": {
+    "level": "INFO",
+    "json": true
+  },
+  "feeds": {
+    "default_tags": [
+      "technology",
+      "business"
+    ],
+    "sources": []
+  }
+}


### PR DESCRIPTION
## Summary
- add a defaults configuration file that captures runtime, path, ingestion, LLM, logging, and feed settings
- provide an `.env.example` with placeholder environment variables for local setup

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68dc91464238832e9a1fcbc976f74a73