### PR TITLE
Add configuration loader with environment overrides

### DIFF
--- a/src/common/config.py
+++ b/src/common/config.py
@@ -1,0 +1,148 @@
+"""Configuration loading utilities for the podcast theme analyzer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import json
+import os
+
+try:  # pragma: no cover - dependency availability varies in tests
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback when PyYAML missing
+    yaml = None  # type: ignore
+
+
+DEFAULTS_PATH = Path("config/defaults.yaml")
+USER_CONFIG_PATH = Path("config.yaml")
+ENV_PREFIX = "PODCAST_THEME_ANALYZER"
+
+
+def load_config(
+    defaults_path: Path = DEFAULTS_PATH,
+    user_config_path: Path = USER_CONFIG_PATH,
+    *,
+    env: Mapping[str, str] | None = None,
+    env_prefix: str = ENV_PREFIX,
+) -> Mapping[str, Any]:
+    """Load configuration merging YAML defaults, optional user config and env vars.
+
+    Parameters
+    ----------
+    defaults_path:
+        Path to the base configuration YAML file.
+    user_config_path:
+        Path to an optional user configuration YAML file.
+    env:
+        Mapping providing environment variables (defaults to ``os.environ``).
+    env_prefix:
+        Prefix used to select environment variables for overrides. Nested keys
+        are delimited with double underscores (``__``).
+
+    Returns
+    -------
+    Mapping[str, Any]
+        An immutable mapping representing the merged configuration.
+    """
+
+    if env is None:
+        env = os.environ
+
+    config: dict[str, Any] = {}
+
+    if defaults_path.exists():
+        config = _deep_merge(config, _load_yaml(defaults_path))
+
+    if user_config_path.exists():
+        config = _deep_merge(config, _load_yaml(user_config_path))
+
+    env_overrides = _env_to_overrides(env, env_prefix)
+    if env_overrides:
+        config = _deep_merge(config, env_overrides)
+
+    return _deep_freeze(config)
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    data = _parse_yaml(text)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at root of {path}, got {type(data)!r}")
+
+    return data
+
+
+def _deep_merge(base: dict[str, Any], overrides: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(base)
+    for key, value in overrides.items():
+        if (
+            key in result
+            and isinstance(result[key], dict)
+            and isinstance(value, Mapping)
+        ):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def _env_to_overrides(env: Mapping[str, str], prefix: str) -> dict[str, Any]:
+    if not prefix:
+        relevant_items = env.items()
+    else:
+        prefix_with_sep = f"{prefix}__"
+        relevant_items = (
+            (key[len(prefix_with_sep) :], value)
+            for key, value in env.items()
+            if key.startswith(prefix_with_sep)
+        )
+
+    overrides: dict[str, Any] = {}
+
+    for compound_key, raw_value in relevant_items:
+        if not compound_key:
+            continue
+
+        keys = [segment.lower() for segment in compound_key.split("__") if segment]
+        if not keys:
+            continue
+
+        cursor = overrides
+        for part in keys[:-1]:
+            cursor = cursor.setdefault(part, {})  # type: ignore[assignment]
+
+        cursor[keys[-1]] = _parse_yaml_value(raw_value)
+
+    return overrides
+
+
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({k: _deep_freeze(v) for k, v in value.items()})
+    if isinstance(value, list):
+        return tuple(_deep_freeze(item) for item in value)
+    return value
+
+
+def _parse_yaml(text: str) -> Any:
+    if yaml is not None:
+        return yaml.safe_load(text) or {}
+
+    text = text.strip()
+    if not text:
+        return {}
+    return json.loads(text)
+
+
+def _parse_yaml_value(text: str) -> Any:
+    if yaml is not None:
+        return yaml.safe_load(text)
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+import pytest
+
+from common.config import ENV_PREFIX, load_config
+
+
+def test_environment_overrides_yaml(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(f"{ENV_PREFIX}__INGESTION__POLL_INTERVAL_SECONDS", "120")
+
+    config = load_config()
+
+    assert config["ingestion"]["poll_interval_seconds"] == 120
+
+
+def test_config_is_immutable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    defaults = tmp_path / "defaults.yaml"
+    defaults.write_text('{"runtime": {"environment": "development"}}', encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+
+    config = load_config(defaults_path=defaults, user_config_path=Path("missing"))
+
+    with pytest.raises(TypeError):
+        config["runtime"] = {"environment": "production"}
+


### PR DESCRIPTION
## Summary
- add a configuration loader that merges defaults, optional user config, and environment overrides
- expose immutable configuration mappings and fallback parsers when PyYAML is unavailable
- add pytest coverage to confirm environment precedence and immutability

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc92f8faf4832e9884ad5f07350f31