### PR TITLE
Add transactional schema setup and constraint tests for DuckDB

### DIFF
--- a/src/ingestion/db.py
+++ b/src/ingestion/db.py
@@ -88,6 +88,13 @@ def initialize_database(db_path: Path = DEFAULT_DB_PATH) -> DuckDBPyConnection:
 def _run_schema_statements(
     connection: DuckDBPyConnection, statements: Iterable[str]
 ) -> None:
-    for statement in statements:
-        connection.execute(statement)
+    connection.execute("BEGIN TRANSACTION")
+    try:
+        for statement in statements:
+            connection.execute(statement)
+    except Exception:  # pragma: no cover - defensive rollback
+        connection.execute("ROLLBACK")
+        raise
+    else:
+        connection.execute("COMMIT")
 


### PR DESCRIPTION
## Summary
- run ingestion schema DDL inside an explicit DuckDB transaction with rollback handling
- expand ingestion database tests to cover unique and foreign key constraints on the shows and episodes tables

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc961e9b50832eb88a4ad930d437c7