### PR TITLE
Add migration tracking for ingestion schema

### DIFF
--- a/src/ingestion/db.py
+++ b/src/ingestion/db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
@@ -11,59 +12,73 @@ from duckdb import DuckDBPyConnection
 
 DEFAULT_DB_PATH = Path("data") / "ingestion.duckdb"
 
-_DDL_STATEMENTS: tuple[str, ...] = (
-    """
-    CREATE TABLE IF NOT EXISTS shows (
-        show_id TEXT PRIMARY KEY,
-        title TEXT,
-        canonical_rss_url TEXT UNIQUE,
-        publisher TEXT,
-        lang TEXT,
-        last_crawl_at TIMESTAMP
-    )
-    """.strip(),
-    """
-    CREATE TABLE IF NOT EXISTS episodes (
-        episode_id TEXT PRIMARY KEY,
-        show_id TEXT REFERENCES shows(show_id),
-        guid TEXT,
-        title TEXT,
-        pubdate TIMESTAMP,
-        duration_s INTEGER,
-        audio_url TEXT,
-        transcript_url TEXT,
-        enclosure_type TEXT,
-        explicit BOOLEAN,
-        episode_type TEXT,
-        season_n INTEGER,
-        episode_n INTEGER,
-        first_seen_at TIMESTAMP,
-        last_seen_at TIMESTAMP,
-        tombstoned_bool BOOLEAN
-    )
-    """.strip(),
-    """
-    CREATE TABLE IF NOT EXISTS source_meta (
-        resource_url TEXT PRIMARY KEY,
-        etag TEXT,
-        last_modified TEXT,
-        last_status INTEGER,
-        last_fetch_ts TIMESTAMP,
-        content_sha256 TEXT,
-        bytes INTEGER
-    )
-    """.strip(),
-    """
-    CREATE TABLE IF NOT EXISTS provenance (
-        object_type TEXT,
-        object_id TEXT,
-        source_url TEXT,
-        fetched_at TIMESTAMP,
-        parser_version TEXT,
-        notes TEXT,
-        PRIMARY KEY (object_type, object_id, source_url, fetched_at)
-    )
-    """.strip(),
+
+@dataclass(frozen=True)
+class Migration:
+    """Single schema migration represented by a set of SQL statements."""
+
+    name: str
+    statements: tuple[str, ...]
+
+
+_MIGRATIONS: tuple[Migration, ...] = (
+    Migration(
+        name="0001_initial_schema",
+        statements=(
+            """
+            CREATE TABLE IF NOT EXISTS shows (
+                show_id TEXT PRIMARY KEY,
+                title TEXT,
+                canonical_rss_url TEXT UNIQUE,
+                publisher TEXT,
+                lang TEXT,
+                last_crawl_at TIMESTAMP
+            )
+            """.strip(),
+            """
+            CREATE TABLE IF NOT EXISTS episodes (
+                episode_id TEXT PRIMARY KEY,
+                show_id TEXT REFERENCES shows(show_id),
+                guid TEXT,
+                title TEXT,
+                pubdate TIMESTAMP,
+                duration_s INTEGER,
+                audio_url TEXT,
+                transcript_url TEXT,
+                enclosure_type TEXT,
+                explicit BOOLEAN,
+                episode_type TEXT,
+                season_n INTEGER,
+                episode_n INTEGER,
+                first_seen_at TIMESTAMP,
+                last_seen_at TIMESTAMP,
+                tombstoned_bool BOOLEAN
+            )
+            """.strip(),
+            """
+            CREATE TABLE IF NOT EXISTS source_meta (
+                resource_url TEXT PRIMARY KEY,
+                etag TEXT,
+                last_modified TEXT,
+                last_status INTEGER,
+                last_fetch_ts TIMESTAMP,
+                content_sha256 TEXT,
+                bytes INTEGER
+            )
+            """.strip(),
+            """
+            CREATE TABLE IF NOT EXISTS provenance (
+                object_type TEXT,
+                object_id TEXT,
+                source_url TEXT,
+                fetched_at TIMESTAMP,
+                parser_version TEXT,
+                notes TEXT,
+                PRIMARY KEY (object_type, object_id, source_url, fetched_at)
+            )
+            """.strip(),
+        ),
+    ),
 )
 
 
@@ -81,17 +96,47 @@ def initialize_database(db_path: Path = DEFAULT_DB_PATH) -> DuckDBPyConnection:
     """Ensure the database exists and run all schema migrations."""
 
     connection = open_database(db_path)
-    _run_schema_statements(connection, _DDL_STATEMENTS)
+    _ensure_schema_migrations_table(connection)
+    _run_pending_migrations(connection, _MIGRATIONS)
     return connection
 
 
-def _run_schema_statements(
-    connection: DuckDBPyConnection, statements: Iterable[str]
+def _ensure_schema_migrations_table(connection: DuckDBPyConnection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
+            migration_name TEXT PRIMARY KEY,
+            applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+        """.strip()
+    )
+
+
+def _run_pending_migrations(
+    connection: DuckDBPyConnection, migrations: Iterable[Migration]
 ) -> None:
+    applied = {
+        row[0]
+        for row in connection.execute(
+            "SELECT migration_name FROM schema_migrations"
+        ).fetchall()
+    }
+
+    for migration in migrations:
+        if migration.name in applied:
+            continue
+        _apply_migration(connection, migration)
+
+
+def _apply_migration(connection: DuckDBPyConnection, migration: Migration) -> None:
     connection.execute("BEGIN TRANSACTION")
     try:
-        for statement in statements:
+        for statement in migration.statements:
             connection.execute(statement)
+        connection.execute(
+            "INSERT INTO schema_migrations (migration_name) VALUES (?)",
+            (migration.name,),
+        )
     except Exception:  # pragma: no cover - defensive rollback
         connection.execute("ROLLBACK")
         raise

--- a/tests/test_ingestion_db.py
+++ b/tests/test_ingestion_db.py
@@ -185,6 +185,14 @@ def test_episodes_show_id_foreign_key_enforced(migrated_connection) -> None:
     assert rows == [("episode-1", "show-1", "Good Episode")]
 
 
+def test_schema_migrations_recorded(migrated_connection) -> None:
+    rows = migrated_connection.execute(
+        "SELECT migration_name FROM schema_migrations ORDER BY applied_at"
+    ).fetchall()
+
+    assert rows == [("0001_initial_schema",)]
+
+
 def test_initialize_database_idempotent(tmp_path: Path) -> None:
     db_path = tmp_path / "ingestion.duckdb"
 
@@ -199,8 +207,12 @@ def test_initialize_database_idempotent(tmp_path: Path) -> None:
 
     second = initialize_database(db_path)
     try:
-        rows = second.execute("SELECT show_id, title FROM shows").fetchall()
-        assert rows == [("show-1", "Test Show")]
+        shows = second.execute("SELECT show_id, title FROM shows").fetchall()
+        migrations = second.execute(
+            "SELECT migration_name FROM schema_migrations"
+        ).fetchall()
+        assert shows == [("show-1", "Test Show")]
+        assert migrations == [("0001_initial_schema",)]
     finally:
         second.close()
 


### PR DESCRIPTION
## Summary
- introduce a simple migration registry for the ingestion DuckDB schema
- ensure schema_migrations metadata table is created and pending migrations are applied
- expand database tests to cover migration bookkeeping and idempotent re-runs

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc97e6b8a0832eb3a42d9e1667bde0