### PR TITLE
Add schema assertions for provenance table

### DIFF
--- a/tests/test_ingestion_db.py
+++ b/tests/test_ingestion_db.py
@@ -181,6 +181,30 @@ def test_source_meta_table_types_and_primary_key(migrated_connection) -> None:
     }
 
 
+def test_provenance_table_schema(migrated_connection) -> None:
+    assert _column_names(migrated_connection, "provenance") == [
+        "object_type",
+        "object_id",
+        "source_url",
+        "fetched_at",
+        "parser_version",
+        "notes",
+    ]
+
+
+def test_provenance_table_types_and_primary_key(migrated_connection) -> None:
+    info = _column_types(migrated_connection, "provenance")
+
+    assert info == {
+        "object_type": ("TEXT", True),
+        "object_id": ("TEXT", True),
+        "source_url": ("TEXT", True),
+        "fetched_at": ("TIMESTAMP", True),
+        "parser_version": ("TEXT", False),
+        "notes": ("TEXT", False),
+    }
+
+
 def test_provenance_insert_select(migrated_connection) -> None:
     migrated_connection.execute(
         """


### PR DESCRIPTION
## Summary
- add schema checks for the provenance table to ensure expected columns are present
- assert provenance table column types and composite primary key configuration

## Testing
- pytest tests/test_ingestion_db.py

------
https://chatgpt.com/codex/tasks/task_e_68dca1efa804832eb8a3eb8486b23465